### PR TITLE
Fix hide chat toggle triggered by media keys

### DIFF
--- a/common/src/main/kotlin/com/ebicep/chatplus/config/serializers/KeyWithModifier.kt
+++ b/common/src/main/kotlin/com/ebicep/chatplus/config/serializers/KeyWithModifier.kt
@@ -22,7 +22,7 @@ data class KeyWithModifier(
     }
 
     fun isDown(keyCode: Int, modifier: Int): Boolean {
-        return key.value == keyCode && (this.modifier == 0.toShort() || this.modifier == modifier.toShort())
+        return key.value != -1 && key.value == keyCode && (this.modifier == 0.toShort() || this.modifier == modifier.toShort())
     }
 
 }


### PR DESCRIPTION
Pressing media keys on the keyboard toggles the chat visibility even when the hide chat key is not assigned, as media key values are recognized as `-1`. This PR resolves the issue by adding a simple check to ensure that the key value is not `-1`.